### PR TITLE
add python object to json auto conversion feature, test and doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,3 +57,4 @@ install:
     - make -j2 install
 script:
     - ./test/test_pybind11_json
+    - python ./test/test_pybind11_json.py

--- a/README.md
+++ b/README.md
@@ -22,6 +22,35 @@ nl::json j = obj;  // Automatic py::object->nl::json conversion
 py::object o = j;  // Automatic nl::json->py::object conversion
 ```
 
+## Automatic conversion between nl::json and python dict object
+
+C++ functions in [test/pybind11_json_module.cpp](test/pybind11_json_module.cpp)
+```cpp
+void print_pyobject_as_json(nlohmann::json s) {
+    std::cout << "print_pyobject_as_json(): " << s << std::endl;
+}
+nlohmann::json return_json_as_pyobject() {
+    nlohmann::json j = {{"pi", 3.141}};
+    std::cout << "return_json_as_pyobject() : "  << j<< std::endl;
+    return j;
+}
+
+pybind11 binding code
+```
+    m.def("print_pyobject_as_json", &print_pyobject_as_json, "pass py::object to c++");
+    m.def("return_json_as_pyobject", &return_json_as_pyobject, "get py::object from c++");
+```cpp
+
+```
+on python side, see [test/test_pybind11_json.py](test/test_pybind11_json.py)
+```python
+import pyjson
+pyjson.print_pyobject_as_json({"value": 2})
+dd = pyjson.return_json_as_pyobject()
+print(dd) 
+
+```
+
 # Installation
 
 ## Using conda
@@ -47,6 +76,11 @@ cmake -D CMAKE_INSTALL_PREFIX=your_conda_path
 make install
 ```
 
+## Header only
+
+Download the "pybind11_json.hpp", "json.hpp" single file into your project, and install/download pybind11 or use as git submodule. 
+Check header path for `json.hpp` and `pybind11`, then you are ready to go.
+
 ## Run tests
 
 You can compile and run tests locally doing
@@ -55,6 +89,7 @@ You can compile and run tests locally doing
 cmake -D CMAKE_INSTALL_PREFIX=$CONDA_PREFIX -D DOWNLOAD_GTEST=ON ..
 make
 ./test/test_pybind11_json
+python ./test/test_pybind11_json.py
 ```
 
 # Dependencies

--- a/include/pybind11_json/pybind11_json.hpp
+++ b/include/pybind11_json/pybind11_json.hpp
@@ -129,4 +129,49 @@ namespace nlohmann
 
 }
 
+namespace pybind11
+{
+namespace detail
+{
+template <>
+struct type_caster<nlohmann::json>
+{
+public:
+    /**
+         * This macro establishes the name 'user_type' in
+         * function signatures and declares a local variable 'value' of user type
+         */
+    PYBIND11_TYPE_CASTER(nlohmann::json, _("json"));
+
+    /**
+         * Conversion part 1 (Python->C++): convert a PyObject into a inty
+         * instance or return false upon failure. The second argument
+         * indicates whether implicit conversions should be applied.
+         */
+    bool load(handle src, bool)
+    {
+        /* Extract PyObject from handle */
+        /* Now try to convert into a C++ type */
+        value = nlohmann::detail::to_json_impl(src);
+        if (value.is_null())
+            return false;
+        return true;
+    }
+
+    /**
+         * Conversion part 2 (C++ -> Python): convert an inty instance into
+         * a Python object. The second and third arguments are used to
+         * indicate the return value policy and parent object (for
+         * ``return_value_policy::reference_internal``) and are generally
+         * ignored by implicit casters.
+         */
+    static handle cast(nlohmann::json src, return_value_policy /* policy */, handle /* parent */)
+    {
+        object pyo = nlohmann::detail::from_json_impl(src);
+        return pyo.release();
+    }
+};
+} // namespace detail
+} // namespace pybind11
+
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -82,8 +82,18 @@ endif()
 
 include_directories(${PYTHON_INCLUDE_DIRS})
 target_link_libraries(test_pybind11_json ${PYTHON_LIBRARIES} ${GTEST_BOTH_LIBRARIES}
-                      pybind11::embed nlohmann_json::nlohmann_json)
+                      pybind11::embed nlohmann_json::nlohmann_json)  # nlohmann_json can be header only
 target_include_directories(test_pybind11_json PRIVATE ${PYBIND11_JSON_INCLUDE_DIR})
 
 add_custom_target(tests COMMAND test_pybind11_json DEPENDS test_pybind11_json)
+
+# a python module is used to test the correctness of auto conversion
+pybind11_add_module(pyjson pybind11_json_module.cpp  )  # generate pyjson python module
+# copy to test source folder, to run the python test
+set_target_properties( pyjson
+    PROPERTIES
+    ARCHIVE_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}/test/"
+    LIBRARY_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}/test/"
+    RUNTIME_OUTPUT_DIRECTORY "${PROJECT_SOURCE_DIR}/test/"
+)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -90,7 +90,7 @@ add_custom_target(tests COMMAND test_pybind11_json DEPENDS test_pybind11_json)
 # a python module is used to test the correctness of auto conversion
 pybind11_add_module(pyjson pybind11_json_module.cpp  )  # generate pyjson python module
 target_include_directories(pyjson PRIVATE ${PYBIND11_JSON_INCLUDE_DIR})
-target_link_libraries(pyjson nlohmann_json::nlohmann_json)  # nlohmann_json can be header only
+#target_link_libraries(pyjson nlohmann_json::nlohmann_json)  # nlohmann_json can be header only
 # copy to test source folder, to run the python test
 set_target_properties( pyjson
     PROPERTIES

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -89,6 +89,8 @@ add_custom_target(tests COMMAND test_pybind11_json DEPENDS test_pybind11_json)
 
 # a python module is used to test the correctness of auto conversion
 pybind11_add_module(pyjson pybind11_json_module.cpp  )  # generate pyjson python module
+target_include_directories(pyjson PRIVATE ${PYBIND11_JSON_INCLUDE_DIR})
+target_link_libraries(pyjson nlohmann_json::nlohmann_json)  # nlohmann_json can be header only
 # copy to test source folder, to run the python test
 set_target_properties( pyjson
     PROPERTIES

--- a/test/pybind11_json_module.cpp
+++ b/test/pybind11_json_module.cpp
@@ -1,0 +1,55 @@
+#include "../include/pybind11_json/pybind11_json.hpp"
+#include <iostream>
+
+void print_pyobject_as_json(nlohmann::json s) {
+    std::cout << "print_pyobject_as_json(): " << s << std::endl;
+}
+nlohmann::json return_json_as_pyobject() {
+    nlohmann::json j = {{"pi", 3.141}};
+    std::cout << "return_json_as_pyobject() : "  << j<< std::endl;
+    return j;
+}
+
+//=================================
+PYBIND11_MODULE(pyjson, m) {
+    m.doc() = "pyjson module"; // optional module docstring
+
+    /* other choice:  wrap this json C++ type,  but it is a complicate class,    
+    py::class_<nlohmann::json>(m, "json")
+        .def(py::init<>())
+        .def(py::init<py::object>())
+    ; */
+
+    //py::implicitly_convertible<py::object, nlohmann::json>();  // error
+    //ImportError: implicitly_convertible: Unable to find type nlohmann::basic_json
+
+    // Dummy json
+    m.def("dummy_json", []() {
+        const nlohmann::json j = {
+            {"pi", 3.141},
+            {"happy", true},
+            {"name", "Niels"},
+            {"nothing", nullptr},
+            {"answer", {
+                {"everything", 42}
+            }},
+            {"list", {1, 0, 2}},
+            {"object", {
+                {"currency", "USD"},
+                {"value", 42.99}
+            }}
+        };
+        //return j;
+        py::object out = j;
+        return out;
+    }, "returns a dummy json object");
+
+    m.def("print_json", [](const py::object in) {
+        const nlohmann::json j = in;
+        std::cout << j;
+    }, "pass py::object to c++");
+
+    m.def("print_pyobject_as_json", &print_pyobject_as_json, "pass py::object to c++");
+    m.def("return_json_as_pyobject", &return_json_as_pyobject, "get py::object from c++");
+
+}

--- a/test/pybind11_json_module.cpp
+++ b/test/pybind11_json_module.cpp
@@ -1,11 +1,12 @@
-#include "../include/pybind11_json/pybind11_json.hpp"
+//#include "../include/pybind11_json/pybind11_json.hpp"
+#include "pybind11_json/pybind11_json.hpp"
 #include <iostream>
 
 void print_pyobject_as_json(nlohmann::json s) {
     std::cout << "print_pyobject_as_json(): " << s << std::endl;
 }
 nlohmann::json return_json_as_pyobject() {
-    nlohmann::json j = {{"pi", 3.141}};
+    nlohmann::json j = {{"value", 1}};
     std::cout << "return_json_as_pyobject() : "  << j<< std::endl;
     return j;
 }

--- a/test/test_pybind11_json.py
+++ b/test/test_pybind11_json.py
@@ -1,0 +1,16 @@
+#!/usr/bin/python3
+
+# test passed on ubuntu 18.04 python3.6
+
+import os.path
+import sys
+
+#sys.path.append("./build")
+
+import pyjson
+d = pyjson.dummy_json()
+pyjson.print_json({"value": 1})
+pyjson.print_pyobject_as_json({"value": 2})
+dd = pyjson.return_json_as_pyobject()
+print(dd) 
+

--- a/test/test_pybind11_json.py
+++ b/test/test_pybind11_json.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python3
 
+from __future__ import print_function
 # test passed on ubuntu 18.04 python3.6
 
 import os.path
@@ -13,4 +14,5 @@ pyjson.print_json({"value": 1})
 pyjson.print_pyobject_as_json({"value": 2})
 dd = pyjson.return_json_as_pyobject()
 print(dd) 
+assert(dd["value"] == 1)
 


### PR DESCRIPTION

I am not sure if the CI test break, I will see what happens after PR.

Just wondering, why the 2 dep version is so low, and fixed in cmake, acturally, it works with latest version. 