### PR TITLE
Use CMake ARCH_INDEPENDENT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ endif()
 
 include(CMakePackageConfigHelpers)
 
-set(PYBIND11_JSON_CMAKECONFIG_INSTALL_DIR "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}" CACHE STRING "install path for pybind11_jsonConfig.cmake")
+set(PYBIND11_JSON_CMAKECONFIG_INSTALL_DIR "${CMAKE_INSTALL_DATAROOTDIR}/cmake/${PROJECT_NAME}" CACHE STRING "install path for pybind11_jsonConfig.cmake")
 
 # Install pybind11_json
 if(CMAKE_VERSION VERSION_LESS 3.15)  # CMake < 3.15
@@ -115,7 +115,8 @@ configure_package_config_file(${PROJECT_NAME}Config.cmake.in
 
 write_basic_package_version_file(${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
                                  VERSION ${${PROJECT_NAME}_VERSION}
-                                 COMPATIBILITY AnyNewerVersion)
+                                 COMPATIBILITY AnyNewerVersion
+                                 ARCH_INDEPENDENT)
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${PROJECT_NAME}Config.cmake
               ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
         DESTINATION ${PYBIND11_JSON_CMAKECONFIG_INSTALL_DIR})


### PR DESCRIPTION
The current configuration generates a pointer-size check in `pybind11_jsonConfigVersion.cmake`, and installs the CMake files in `CMAKE_INSTALL_LIBDIR`, which on (some) systems will be an architecture-specific directory like `usr/lib/x86_64-linux-gnu`.

Since the library is header only, it shouldn't be necessary to encode any architecture dependence in the result.

(This matches changes in `pybind11`: https://github.com/pybind/pybind11/pull/2584 https://github.com/pybind/pybind11/pull/2338 )