### PR TITLE
Use nlohmann built-ins to distinguish integers and floats

### DIFF
--- a/include/pybind11_json/pybind11_json.hpp
+++ b/include/pybind11_json/pybind11_json.hpp
@@ -11,6 +11,7 @@
 
 #include <string>
 #include <vector>
+#include <cmath>
 
 #include "nlohmann/json.hpp"
 
@@ -34,7 +35,7 @@ namespace pyjson
         else if (j.is_number())
         {
             double number = j.get<double>();
-            if (number == std::floor(number))
+            if (isfinite(number) && number == std::floor(number))
             {
                 return py::int_(j.get<long>());
             }

--- a/include/pybind11_json/pybind11_json.hpp
+++ b/include/pybind11_json/pybind11_json.hpp
@@ -32,17 +32,13 @@ namespace pyjson
         {
             return py::bool_(j.get<bool>());
         }
-        else if (j.is_number())
+        else if (j.is_number_integer())
         {
-            double number = j.get<double>();
-            if (isfinite(number) && number == std::floor(number))
-            {
-                return py::int_(j.get<long>());
-            }
-            else
-            {
-                return py::float_(number);
-            }
+            return py::int_(j.get<long>());
+        }
+        else if (j.is_number_float())
+        {
+            return py::float_(j.get<double>());
         }
         else if (j.is_string())
         {

--- a/include/pybind11_json/pybind11_json.hpp
+++ b/include/pybind11_json/pybind11_json.hpp
@@ -11,7 +11,6 @@
 
 #include <string>
 #include <vector>
-#include <cmath>
 
 #include "nlohmann/json.hpp"
 

--- a/test/test_pybind11_json.cpp
+++ b/test/test_pybind11_json.cpp
@@ -8,6 +8,7 @@
 
 #include <string>
 #include <vector>
+#include <cmath>
 
 #include "gtest/gtest.h"
 
@@ -48,14 +49,26 @@ TEST(nljson_serializers_tojson, number)
     py::int_ obj(36);
     nl::json j = obj;
 
-    ASSERT_TRUE(j.is_number());
+    ASSERT_TRUE(j.is_number_integer());
     ASSERT_EQ(j.get<int>(), 36);
 
     py::float_ obj2(36.37);
     nl::json j2 = obj2;
 
-    ASSERT_TRUE(j2.is_number());
+    ASSERT_TRUE(j2.is_number_float());
     ASSERT_EQ(j2.get<double>(), 36.37);
+
+    py::float_ obj3(INFINITY);
+    nl::json j3 = obj3;
+
+    ASSERT_TRUE(j3.is_number_float());
+    ASSERT_EQ(j3.get<double>(), INFINITY);
+
+    py::float_ obj4(NAN);
+    nl::json j4 = obj4;
+
+    ASSERT_TRUE(j4.is_number_float());
+    ASSERT_TRUE(isnan(j4.get<double>()));
 }
 
 TEST(nljson_serializers_tojson, string)
@@ -179,7 +192,7 @@ TEST(nljson_serializers_tojson, list_accessor)
     ASSERT_TRUE(j.is_object());
 
     j = py::make_tuple(1234, "hello", false)[0];
-    ASSERT_TRUE(j.is_number());
+    ASSERT_TRUE(j.is_number_integer());
     ASSERT_EQ(j.get<int>(), 1234);
 }
 
@@ -189,7 +202,7 @@ TEST(nljson_serializers_tojson, tuple_accessor)
     py::tuple obj = py::make_tuple(1234, "hello", false);
 
     nl::json j = obj[0];
-    ASSERT_TRUE(j.is_number());
+    ASSERT_TRUE(j.is_number_integer());
     ASSERT_EQ(j.get<int>(), 1234);
 
     j = obj[1];
@@ -276,6 +289,26 @@ TEST(nljson_serializers_fromjson, number)
     py::float_ obj4 = j2;
 
     ASSERT_EQ(obj4.cast<double>(), 36.2);
+
+    nl::json j3(INFINITY);
+    py::object obj5 = j3;
+
+    ASSERT_TRUE(py::isinstance<py::float_>(obj5));
+    ASSERT_EQ(obj5.cast<double>(), INFINITY);
+
+    py::float_ obj6 = j3;
+
+    ASSERT_EQ(obj6.cast<double>(), INFINITY);
+
+    nl::json j4(NAN);
+    py::object obj7 = j4;
+
+    ASSERT_TRUE(py::isinstance<py::float_>(obj7));
+    ASSERT_TRUE(isnan(obj7.cast<double>()));
+
+    py::float_ obj8 = j4;
+
+    ASSERT_TRUE(isnan(obj8.cast<double>()));
 }
 
 TEST(nljson_serializers_fromjson, string)

--- a/test/test_pybind11_json.cpp
+++ b/test/test_pybind11_json.cpp
@@ -43,7 +43,7 @@ TEST(nljson_serializers_tojson, bool_)
     ASSERT_FALSE(j.get<bool>());
 }
 
-TEST(nljson_serializers_tojson, number)
+TEST(nljson_serializers_tojson, integer)
 {
     py::scoped_interpreter guard;
     py::int_ obj(36);
@@ -51,7 +51,10 @@ TEST(nljson_serializers_tojson, number)
 
     ASSERT_TRUE(j.is_number_integer());
     ASSERT_EQ(j.get<int>(), 36);
+}
 
+TEST(nljson_serializers_tojson, float_)
+{
     py::float_ obj2(36.37);
     nl::json j2 = obj2;
 
@@ -267,7 +270,7 @@ TEST(nljson_serializers_fromjson, bool_)
     ASSERT_FALSE(obj2.cast<bool>());
 }
 
-TEST(nljson_serializers_fromjson, number)
+TEST(nljson_serializers_fromjson, integer)
 {
     py::scoped_interpreter guard;
     nl::json j = "36"_json;
@@ -279,7 +282,10 @@ TEST(nljson_serializers_fromjson, number)
     py::int_ obj2 = j;
 
     ASSERT_EQ(obj2.cast<int>(), 36);
+}
 
+TEST(nljson_serializers_fromjson, float_)
+{
     nl::json j2 = "36.2"_json;
     py::object obj3 = j2;
 

--- a/test/test_pybind11_json.cpp
+++ b/test/test_pybind11_json.cpp
@@ -55,23 +55,23 @@ TEST(nljson_serializers_tojson, integer)
 
 TEST(nljson_serializers_tojson, float_)
 {
-    py::float_ obj2(36.37);
-    nl::json j2 = obj2;
+    py::float_ obj(36.37);
+    nl::json j = obj;
 
-    ASSERT_TRUE(j2.is_number_float());
-    ASSERT_EQ(j2.get<double>(), 36.37);
+    ASSERT_TRUE(j.is_number_float());
+    ASSERT_EQ(j.get<double>(), 36.37);
 
-    py::float_ obj3(INFINITY);
-    nl::json j3 = obj3;
+    py::float_ obj_inf(INFINITY);
+    nl::json j_inf = obj_inf;
 
-    ASSERT_TRUE(j3.is_number_float());
-    ASSERT_EQ(j3.get<double>(), INFINITY);
+    ASSERT_TRUE(j_inf.is_number_float());
+    ASSERT_EQ(j_inf.get<double>(), INFINITY);
 
-    py::float_ obj4(NAN);
-    nl::json j4 = obj4;
+    py::float_ obj_nan(NAN);
+    nl::json j_nan = obj_nan;
 
-    ASSERT_TRUE(j4.is_number_float());
-    ASSERT_TRUE(isnan(j4.get<double>()));
+    ASSERT_TRUE(j_nan.is_number_float());
+    ASSERT_TRUE(isnan(j_nan.get<double>()));
 }
 
 TEST(nljson_serializers_tojson, string)
@@ -286,35 +286,35 @@ TEST(nljson_serializers_fromjson, integer)
 
 TEST(nljson_serializers_fromjson, float_)
 {
-    nl::json j2 = "36.2"_json;
-    py::object obj3 = j2;
+    nl::json j = "36.2"_json;
+    py::object obj = j;
 
-    ASSERT_TRUE(py::isinstance<py::float_>(obj3));
-    ASSERT_EQ(obj3.cast<double>(), 36.2);
+    ASSERT_TRUE(py::isinstance<py::float_>(obj));
+    ASSERT_EQ(obj.cast<double>(), 36.2);
 
-    py::float_ obj4 = j2;
+    py::float_ f_obj = j;
 
-    ASSERT_EQ(obj4.cast<double>(), 36.2);
+    ASSERT_EQ(f_obj.cast<double>(), 36.2);
 
-    nl::json j3(INFINITY);
-    py::object obj5 = j3;
+    nl::json j_inf(INFINITY);
+    py::object obj_inf = j_inf;
 
-    ASSERT_TRUE(py::isinstance<py::float_>(obj5));
-    ASSERT_EQ(obj5.cast<double>(), INFINITY);
+    ASSERT_TRUE(py::isinstance<py::float_>(obj_inf));
+    ASSERT_EQ(obj_inf.cast<double>(), INFINITY);
 
-    py::float_ obj6 = j3;
+    py::float_ f_obj_inf = j_inf;
 
-    ASSERT_EQ(obj6.cast<double>(), INFINITY);
+    ASSERT_EQ(f_obj_inf.cast<double>(), INFINITY);
 
-    nl::json j4(NAN);
-    py::object obj7 = j4;
+    nl::json j_nan(NAN);
+    py::object obj_nan = j_nan;
 
-    ASSERT_TRUE(py::isinstance<py::float_>(obj7));
-    ASSERT_TRUE(isnan(obj7.cast<double>()));
+    ASSERT_TRUE(py::isinstance<py::float_>(obj_nan));
+    ASSERT_TRUE(isnan(obj_nan.cast<double>()));
 
-    py::float_ obj8 = j4;
+    py::float_ f_obj_nan = j_nan;
 
-    ASSERT_TRUE(isnan(obj8.cast<double>()));
+    ASSERT_TRUE(isnan(f_obj_nan.cast<double>()));
 }
 
 TEST(nljson_serializers_fromjson, string)


### PR DESCRIPTION
Fixes #38. 

Previously, the function for converting an nl::json object to python checked if the object represented a number using [nl::basic_json::is_number()](https://nlohmann.github.io/json/doxygen/classnlohmann_1_1basic__json_abd47ac8eba63833152795280f75b5851.html#abd47ac8eba63833152795280f75b5851), then used a second test to determine if the number were an integer or float. This second test was incorrect for the value infinity, resulting in #38. Using the functions [nl::basic_json::_is_number_integer()](https://nlohmann.github.io/json/doxygen/classnlohmann_1_1basic__json_ac4b4acf2c0ad075c0dc125a65c102362.html#ac4b4acf2c0ad075c0dc125a65c102362) and [nl::basic_json::_is_number_float()](https://nlohmann.github.io/json/doxygen/classnlohmann_1_1basic__json_a116cdb9300b56519fc9cf756609296cb.html#a116cdb9300b56519fc9cf756609296cb) fixes this issue, and simplifies the code too.

This request also updates the test suite to reflect this change. It splits the two `number` test cases into separate `integer` and `float_` cases, and it adds tests for converting infinity and NaN.