### PR TITLE
Fix find_package guard to enable including pybind11 with add_directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ set(${PROJECT_NAME}_VERSION ${${PROJECT_NAME}_VERSION_MAJOR}.${${PROJECT_NAME}_V
 set(pybind11_REQUIRED_VERSION 2.2.4)
 set(nlohmann_json_REQUIRED_VERSION 3.2.0)
 
-if (NOT TARGET pybind11)
+if (NOT TARGET pybind11::headers)
 find_package(pybind11 ${pybind11_REQUIRED_VERSION} REQUIRED)
 endif()
 if (NOT TARGET nlohmann_json)


### PR DESCRIPTION
Fixes #42. The solution is to replace `pybind11`, which is not a CMake target of pybind11, with `pybind11::headers`, which is one. See [here](https://github.com/pybind/pybind11/blob/c2362393564dee62c692432a97a45d81d84cc217/CMakeLists.txt#L175). I confirmed that this fixes the issue I was seeing.

We could potentially use `pybind11::module` instead. See [here](https://github.com/pybind/pybind11/blob/c2362393564dee62c692432a97a45d81d84cc217/tools/pybind11Config.cmake.in#L31).