### PR TITLE
Fix warnings given while compiling with CLANG

### DIFF
--- a/include/pybind11_json/pybind11_json.hpp
+++ b/include/pybind11_json/pybind11_json.hpp
@@ -93,7 +93,7 @@ namespace pyjson
         if (py::isinstance<py::tuple>(obj) || py::isinstance<py::list>(obj))
         {
             auto out = nl::json::array();
-            for (const py::handle& value : obj)
+            for (const py::handle value : obj)
             {
                 out.push_back(to_json(value));
             }
@@ -102,7 +102,7 @@ namespace pyjson
         if (py::isinstance<py::dict>(obj))
         {
             auto out = nl::json::object();
-            for (const py::handle& key : obj)
+            for (const py::handle key : obj)
             {
                 out[py::str(key).cast<std::string>()] = to_json(obj[key]);
             }


### PR DESCRIPTION
Thanks for the nice work! 

After including the header file in one of my projects I got the following warnings when compiling with CLANG:
```
pybind11_json.hpp:96:36: warning: loop variable 'value' is always a copy because the range of type 'const py::handle' does not return a reference [-Wrange-loop-analysis]
            for (const py::handle& value : obj)
                                   ^
pybind11_json.hpp:96:18: note: use non-reference type 'py::handle'
            for (const py::handle& value : obj)
                 ^~~~~~~~~~~~~~~~~~~~~~~~~
pybind11_json.hpp:105:36: warning: loop variable 'key' is always a copy because the range of type 'const py::handle' does not return a reference [-Wrange-loop-analysis]
            for (const py::handle& key : obj)
                                   ^
pybind11_json.hpp:105:18: note: use non-reference type 'py::handle'
            for (const py::handle& key : obj)
                 ^~~~~~~~~~~~~~~~~~~~~~~
2 warnings generated.
```
TBH, I'm not sure if this is a 'false flag' by the compiler or not and my c++ knowledge doesn't go that far..... See for instance https://stackoverflow.com/questions/50066139/what-is-clangs-range-loop-analysis-diagnostic-about . So, feel free to ignore this pr . 