### PR TITLE
Fix warning when compiling with clang

### DIFF
--- a/include/pybind11_json/pybind11_json.hpp
+++ b/include/pybind11_json/pybind11_json.hpp
@@ -50,7 +50,7 @@ namespace pyjson
             {
                 obj.append(from_json(el));
             }
-            return obj;
+            return std::move(obj);
         }
         else // Object
         {
@@ -59,7 +59,7 @@ namespace pyjson
             {
                 obj[py::str(it.key())] = from_json(it.value());
             }
-            return obj;
+            return std::move(obj);
         }
     }
 


### PR DESCRIPTION
When compiling with Apple clang (version 12.0.0) the following warnings pop up:
```shell
In file included from [...]:
[...]/pybind11_json/include/pybind11_json/pybind11_json.hpp:53:20: warning: local variable 'obj' will be copied despite being returned by name [-Wreturn-std-move]
            return obj;
                   ^~~
[...]/pybind11_json/include/pybind11_json/pybind11_json.hpp:53:20: note: call 'std::move' explicitly to avoid copying
            return obj;
                   ^~~
                   std::move(obj)
[...]/pybind11_json/include/pybind11_json/pybind11_json.hpp:62:20: warning: local variable 'obj' will be copied despite being returned by name [-Wreturn-std-move]
            return obj;
                   ^~~
[...]/pybind11_json/include/pybind11_json/pybind11_json.hpp:62:20: note: call 'std::move' explicitly to avoid copying
            return obj;
                   ^~~
                   std::move(obj)
```

It seems safe to follow clang's suggestion here.

Best regards,
Lukas