### PR TITLE
no semicolon in marco as per gcc warning

### DIFF
--- a/include/pybind11_json/pybind11_json.hpp
+++ b/include/pybind11_json/pybind11_json.hpp
@@ -128,7 +128,7 @@ namespace nlohmann
         {                                                  \
             return pyjson::from_json(j);                   \
         }                                                  \
-    };
+    }
 
     #define MAKE_NLJSON_SERIALIZER_ONLY(T)                 \
     template <>                                            \
@@ -138,7 +138,7 @@ namespace nlohmann
         {                                                  \
             j = pyjson::to_json(obj);                      \
         }                                                  \
-    };
+    }
 
     MAKE_NLJSON_SERIALIZER_DESERIALIZER(py::object);
 


### PR DESCRIPTION
When I compile with gcc version 8.3.1 and use the flag `-Wpedantic`, I get the following warnings:

```
{my project}/_deps/pybind11_json-src/include/pybind11_json/pybind11_json.hpp:143:52: warning: extra ‘;’ [-Wpedantic]
     MAKE_NLJSON_SERIALIZER_DESERIALIZER(py::object);
                                                    ^
{my project}/_deps/pybind11_json-src/include/pybind11_json/pybind11_json.hpp:145:51: warning: extra ‘;’ [-Wpedantic]
     MAKE_NLJSON_SERIALIZER_DESERIALIZER(py::bool_);
                                                   ^
{my project}/_deps/pybind11_json-src/include/pybind11_json/pybind11_json.hpp:146:50: warning: extra ‘;’ [-Wpedantic]
     MAKE_NLJSON_SERIALIZER_DESERIALIZER(py::int_);
                                                  ^
{my project}/_deps/pybind11_json-src/include/pybind11_json/pybind11_json.hpp:147:52: warning: extra ‘;’ [-Wpedantic]
     MAKE_NLJSON_SERIALIZER_DESERIALIZER(py::float_);
                                                    ^
{my project}/_deps/pybind11_json-src/include/pybind11_json/pybind11_json.hpp:148:49: warning: extra ‘;’ [-Wpedantic]
     MAKE_NLJSON_SERIALIZER_DESERIALIZER(py::str);
                                                 ^
{my project}/_deps/pybind11_json-src/include/pybind11_json/pybind11_json.hpp:150:50: warning: extra ‘;’ [-Wpedantic]
     MAKE_NLJSON_SERIALIZER_DESERIALIZER(py::list);
                                                  ^
{my project}/_deps/pybind11_json-src/include/pybind11_json/pybind11_json.hpp:151:51: warning: extra ‘;’ [-Wpedantic]
     MAKE_NLJSON_SERIALIZER_DESERIALIZER(py::tuple);
                                                   ^
{my project}/_deps/pybind11_json-src/include/pybind11_json/pybind11_json.hpp:152:50: warning: extra ‘;’ [-Wpedantic]
     MAKE_NLJSON_SERIALIZER_DESERIALIZER(py::dict);
                                                  ^
{my project}/_deps/pybind11_json-src/include/pybind11_json/pybind11_json.hpp:154:44: warning: extra ‘;’ [-Wpedantic]
     MAKE_NLJSON_SERIALIZER_ONLY(py::handle);
                                            ^
{my project}/_deps/pybind11_json-src/include/pybind11_json/pybind11_json.hpp:155:59: warning: extra ‘;’ [-Wpedantic]
     MAKE_NLJSON_SERIALIZER_ONLY(py::detail::item_accessor);
                                                           ^
{my project}/_deps/pybind11_json-src/include/pybind11_json/pybind11_json.hpp:156:59: warning: extra ‘;’ [-Wpedantic]
     MAKE_NLJSON_SERIALIZER_ONLY(py::detail::list_accessor);
                                                           ^
{my project}/_deps/pybind11_json-src/include/pybind11_json/pybind11_json.hpp:157:60: warning: extra ‘;’ [-Wpedantic]
     MAKE_NLJSON_SERIALIZER_ONLY(py::detail::tuple_accessor);
                                                            ^
{my project}/_deps/pybind11_json-src/include/pybind11_json/pybind11_json.hpp:158:63: warning: extra ‘;’ [-Wpedantic]
     MAKE_NLJSON_SERIALIZER_ONLY(py::detail::sequence_accessor);
                                                               ^
{my project}/_deps/pybind11_json-src/include/pybind11_json/pybind11_json.hpp:159:63: warning: extra ‘;’ [-Wpedantic]
     MAKE_NLJSON_SERIALIZER_ONLY(py::detail::str_attr_accessor);
                                                               ^
{my project}/_deps/pybind11_json-src/include/pybind11_json/pybind11_json.hpp:160:63: warning: extra ‘;’ [-Wpedantic]
     MAKE_NLJSON_SERIALIZER_ONLY(py::detail::obj_attr_accessor);
```

Since the macros `MAKE_NLJSON_SERIALIZER_DESERIALIZER ` and `MAKE_NLJSON_SERIALIZER_ONLY` already have trailing semicolons, it's redundant to add semicolons after calling them. As per [this article](https://wiki.sei.cmu.edu/confluence/display/c/PRE11-C.+Do+not+conclude+macro+definitions+with+a+semicolon), I think the proper solution is to remove the semicolon at the end of the macro definitions.