### PR TITLE
Improved integer value conversion(signed/unsigned and domain check) in order to avoid overflow.

### DIFF
--- a/include/pybind11_json/pybind11_json.hpp
+++ b/include/pybind11_json/pybind11_json.hpp
@@ -79,18 +79,28 @@ namespace pyjson
         }
         if (py::isinstance<py::int_>(obj))
         {
-            try{
-                nl::json::number_integer_t s=obj.cast<nl::json::number_integer_t>();
-                if(py::int_(s).equal(obj)){
+            try
+            {
+                nl::json::number_integer_t s = obj.cast<nl::json::number_integer_t>();
+                if (py::int_(s).equal(obj))
+                {
                     return s;
                 }
-            }catch(...){}
-            try{
-                nl::json::number_unsigned_t u=obj.cast<nl::json::number_unsigned_t>();
-                if(py::int_(u).equal(obj)){
+            }
+            catch (...)
+            {
+            }
+            try
+            {
+                nl::json::number_unsigned_t u = obj.cast<nl::json::number_unsigned_t>();
+                if (py::int_(u).equal(obj))
+                {
                     return u;
                 }
-            }catch(...){}
+            }
+            catch (...)
+            {
+            }
             throw std::runtime_error("to_json received an integer out of range for both nl::json::number_integer_t and nl::json::number_unsigned_t type: " + py::repr(obj).cast<std::string>());
         }
         if (py::isinstance<py::float_>(obj))

--- a/include/pybind11_json/pybind11_json.hpp
+++ b/include/pybind11_json/pybind11_json.hpp
@@ -33,7 +33,11 @@ namespace pyjson
         }
         else if (j.is_number_integer())
         {
-            return py::int_(j.get<long>());
+            return py::int_(j.get<nl::json::number_integer_t>());
+        }
+        else if (j.is_number_unsigned())
+        {
+            return py::int_(j.get<nl::json::number_unsigned_t>());
         }
         else if (j.is_number_float())
         {
@@ -75,7 +79,19 @@ namespace pyjson
         }
         if (py::isinstance<py::int_>(obj))
         {
-            return obj.cast<long>();
+            try{
+                nl::json::number_integer_t s=obj.cast<nl::json::number_integer_t>();
+                if(py::int_(s).equal(obj)){
+                    return s;
+                }
+            }catch(...){}
+            try{
+                nl::json::number_unsigned_t u=obj.cast<nl::json::number_unsigned_t>();
+                if(py::int_(u).equal(obj)){
+                    return u;
+                }
+            }catch(...){}
+            throw std::runtime_error("to_json received an integer out of range for both nl::json::number_integer_t and nl::json::number_unsigned_t type: " + py::repr(obj).cast<std::string>());
         }
         if (py::isinstance<py::float_>(obj))
         {

--- a/test/test_pybind11_json.cpp
+++ b/test/test_pybind11_json.cpp
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 #include <cmath>
+#include <limits>
 
 #include "gtest/gtest.h"
 
@@ -51,6 +52,43 @@ TEST(nljson_serializers_tojson, integer)
 
     ASSERT_TRUE(j.is_number_integer());
     ASSERT_EQ(j.get<int>(), 36);
+
+    py::int_ obj_integer_min(std::numeric_limits<nl::json::number_integer_t>::min());
+    nl::json j_integer_min = obj_integer_min;
+
+    ASSERT_TRUE(j_integer_min.is_number_integer());
+    ASSERT_EQ(j_integer_min.get<nl::json::number_integer_t>(), std::numeric_limits<nl::json::number_integer_t>::min());
+
+    py::int_ obj_unsigned_max(std::numeric_limits<nl::json::number_unsigned_t>::max());
+    nl::json j_unsigned_max = obj_unsigned_max;
+
+    ASSERT_TRUE(j_unsigned_max.is_number_unsigned());
+    ASSERT_EQ(j_unsigned_max.get<nl::json::number_unsigned_t>(), std::numeric_limits<nl::json::number_unsigned_t>::max());
+
+    py::int_ obj_integer_border=py::int_(std::numeric_limits<nl::json::number_integer_t>::max()).attr("__add__")(1);
+    nl::json j_integer_border = obj_integer_border;
+
+    ASSERT_TRUE(j_integer_border.is_number_unsigned());
+    ASSERT_EQ(j_integer_min.get<nl::json::number_unsigned_t>(), (nl::json::number_unsigned_t)(std::numeric_limits<nl::json::number_integer_t>::max())+1);
+
+    py::int_ obj_small_outside=obj_integer_min.attr("__sub__")(1);
+    bool failure;
+    try{
+        nl::json j_small_outside = obj_small_outside;
+        failure=false;
+    }catch(...){
+        failure=true;
+    }
+    ASSERT_TRUE(failure);
+
+    py::int_ obj_large_outside=obj_unsigned_max.attr("__add__")(1);
+    try{
+        nl::json j_large_outside = obj_large_outside;
+        failure=false;
+    }catch(...){
+        failure=true;
+    }
+    ASSERT_TRUE(failure);
 }
 
 TEST(nljson_serializers_tojson, float_)

--- a/test/test_pybind11_json.cpp
+++ b/test/test_pybind11_json.cpp
@@ -65,30 +65,17 @@ TEST(nljson_serializers_tojson, integer)
     ASSERT_TRUE(j_unsigned_max.is_number_unsigned());
     ASSERT_EQ(j_unsigned_max.get<nl::json::number_unsigned_t>(), std::numeric_limits<nl::json::number_unsigned_t>::max());
 
-    py::int_ obj_integer_border=py::int_(std::numeric_limits<nl::json::number_integer_t>::max()).attr("__add__")(1);
+    py::int_ obj_integer_border = py::int_(std::numeric_limits<nl::json::number_integer_t>::max()).attr("__add__")(1);
     nl::json j_integer_border = obj_integer_border;
 
     ASSERT_TRUE(j_integer_border.is_number_unsigned());
-    ASSERT_EQ(j_integer_min.get<nl::json::number_unsigned_t>(), (nl::json::number_unsigned_t)(std::numeric_limits<nl::json::number_integer_t>::max())+1);
+    ASSERT_EQ(j_integer_min.get<nl::json::number_unsigned_t>(), (nl::json::number_unsigned_t)(std::numeric_limits<nl::json::number_integer_t>::max()) + 1);
 
-    py::int_ obj_small_outside=obj_integer_min.attr("__sub__")(1);
-    bool failure;
-    try{
-        nl::json j_small_outside = obj_small_outside;
-        failure=false;
-    }catch(...){
-        failure=true;
-    }
-    ASSERT_TRUE(failure);
+    py::int_ obj_small_outside = obj_integer_min.attr("__sub__")(1);
+    ASSERT_THROW(nl::json j_small_outside = obj_small_outside, std::runtime_error);
 
     py::int_ obj_large_outside=obj_unsigned_max.attr("__add__")(1);
-    try{
-        nl::json j_large_outside = obj_large_outside;
-        failure=false;
-    }catch(...){
-        failure=true;
-    }
-    ASSERT_TRUE(failure);
+    ASSERT_THROW(nl::json j_large_outside = obj_large_outside, std::runtime_error);
 }
 
 TEST(nljson_serializers_tojson, float_)


### PR DESCRIPTION
Improved integer value conversion in order to avoid overflow.
1) signed/unsigned check
 Negative numbers will be casted to signed type,
 and large numbers unrepresentable with signed type will be casted to unsigned type.
2) domain check
 Needed because PyLong can contain any numbers outside the domain of C++ integer type.
 An exception will be thrown when the given value is outside of the domain.
3) use typedef aliases which nl::json actually uses to hold integer values internally.
 nl::json::number_integer_t for signed, and nl::json::number_unsigned_t for unsigned.
 They are std::int64_t and std::uint64_t in default, respectively.

Also, test suite for integer conversion is updated following cases.
1) negative number (INT64_MIN)
2) the maximum number with by unsigned type (UINT64_MAX)
3) the smallest number which is only representable by unsigned type (INT64_MAX+1)
4) smaller than the minimum number with signed type (INT64_MIN-1)
5) larger than the maximum number with unsigned type (UINT64_MAX+1)