### PR TITLE
Fix large unsigned conversions in from_json

### DIFF
--- a/include/pybind11_json/pybind11_json.hpp
+++ b/include/pybind11_json/pybind11_json.hpp
@@ -31,13 +31,13 @@ namespace pyjson
         {
             return py::bool_(j.get<bool>());
         }
-        else if (j.is_number_integer())
-        {
-            return py::int_(j.get<nl::json::number_integer_t>());
-        }
         else if (j.is_number_unsigned())
         {
             return py::int_(j.get<nl::json::number_unsigned_t>());
+        }
+        else if (j.is_number_integer())
+        {
+            return py::int_(j.get<nl::json::number_integer_t>());
         }
         else if (j.is_number_float())
         {

--- a/test/test_pybind11_json.cpp
+++ b/test/test_pybind11_json.cpp
@@ -315,6 +315,27 @@ TEST(nljson_serializers_fromjson, integer)
     ASSERT_EQ(obj2.cast<int>(), 36);
 }
 
+TEST(nljson_serializers_fromjson, integer_large_unsigned)
+{
+    // Note: if the asserts below error, the large number is printed as "-1" with
+    // an overflow error. This is only in the output step in pybind. Calling
+    // py::print on the objects shows the correct large unsigned integer.
+
+    py::scoped_interpreter guard;
+    uint64_t original = 13625394757606569013ull;
+    py::int_ py_orig = original;
+    nl::json j = original;
+    py::object obj = j;
+
+    ASSERT_TRUE(py::isinstance<py::int_>(obj));
+    ASSERT_EQ(obj.cast<uint64_t>(), original);
+
+    py::int_ obj2 = j;
+
+    // Use .equal to compare values not pointers
+    ASSERT_TRUE(obj2.equal(py_orig));
+}
+
 TEST(nljson_serializers_fromjson, float_)
 {
     py::scoped_interpreter guard;


### PR DESCRIPTION
I was noticing that large unsigned 64 ints were being converted from json into a negative python int. I think this is because the `from_json` is first checking if the json object is an integer, and only if that fails to check if it is an unsigned number. So I think the unsigned branch might never be hit.

I flipped the order around, and added a test to check this. One comment about that test, I'm doing a full round trip of `uint64_t` to python int to json to python int, as I want to compare the two python ints without any explicit casting, as that would just cast away the issue.

I actually had trouble debugging this because the default error output of pybind seems not to realise it should be trying to use 64 bit integers (long long) for the printing output and just shows `-1` instead. However, the python objects themselves are fine.