### PR TITLE
refactor: remove redundant move

### DIFF
--- a/include/pybind11_json/pybind11_json.hpp
+++ b/include/pybind11_json/pybind11_json.hpp
@@ -54,7 +54,7 @@ namespace pyjson
             {
                 obj[i] = from_json(j[i]);
             }
-            return std::move(obj);
+            return obj;
         }
         else // Object
         {
@@ -63,7 +63,7 @@ namespace pyjson
             {
                 obj[py::str(it.key())] = from_json(it.value());
             }
-            return std::move(obj);
+            return obj;
         }
     }
 


### PR DESCRIPTION
This removes the redundant move in a couple of return statements