### PR TITLE
CMakeLists.txt: Add support for pkg-config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,3 +133,27 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${PROJECT_NAME}Config.cmake
 install(EXPORT ${PROJECT_NAME}-targets
         FILE ${PROJECT_NAME}Targets.cmake
         DESTINATION ${PYBIND11_JSON_CMAKECONFIG_INSTALL_DIR})
+
+# pkg-config support
+if(NOT prefix_for_pc_file)
+if(IS_ABSOLUTE "${CMAKE_INSTALL_DATAROOTDIR}")
+  set(prefix_for_pc_file "${CMAKE_INSTALL_PREFIX}")
+else()
+  set(pc_datarootdir "${CMAKE_INSTALL_DATAROOTDIR}")
+  if(CMAKE_VERSION VERSION_LESS 3.20)
+    set(prefix_for_pc_file "\${pcfiledir}/..")
+    while(pc_datarootdir)
+      get_filename_component(pc_datarootdir "${pc_datarootdir}" DIRECTORY)
+      string(APPEND prefix_for_pc_file "/..")
+    endwhile()
+  else()
+    cmake_path(RELATIVE_PATH CMAKE_INSTALL_PREFIX BASE_DIRECTORY CMAKE_INSTALL_DATAROOTDIR
+               OUTPUT_VARIABLE prefix_for_pc_file)
+  endif()
+endif()
+endif()
+set(includedir_for_pc_file "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/pybind11_json.pc.in"
+             "${CMAKE_CURRENT_BINARY_DIR}/pybind11_json.pc" @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/pybind11_json.pc"
+      DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig/")

--- a/pybind11_json.pc.in
+++ b/pybind11_json.pc.in
@@ -1,0 +1,7 @@
+prefix=@prefix_for_pc_file@
+includedir=@includedir_for_pc_file@
+
+Name: @PROJECT_NAME@
+Description: Using nlohmann::json with pybind11
+Version: @PROJECT_VERSION@
+Cflags: -I${includedir}


### PR DESCRIPTION
I needed this addition for our Yocto, and think it makes sense to have this when pybind11 also does. I also basically just copied the stuff from pybind11's pkg-config support.